### PR TITLE
Improve avatar rendering and display full user names

### DIFF
--- a/Front-End/src/components/layouts/MapHeader.tsx
+++ b/Front-End/src/components/layouts/MapHeader.tsx
@@ -24,7 +24,8 @@ export default function MapHeader({
   onNavigate,
   onOpenSettings,
 }: MapHeaderProps) {
-  const { isLoggedIn, firstName, email, profileImage, logout } = useAuth();
+  const { isLoggedIn, firstName, lastName, email, profileImage, logout } = useAuth();
+  const fullName = `${firstName} ${lastName}`;
 
   return (
     <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-4 shadow-sm z-20 relative">
@@ -67,11 +68,9 @@ export default function MapHeader({
                   <Avatar className="w-9 h-9">
                     {
                       profileImage ? (
-                        <AvatarImage src={profileImage} alt={firstName} />
+                        <AvatarImage src={profileImage} alt={fullName} className="object-cover w-full h-full" />
                       ) : (
-                        <AvatarFallback className="bg-gradient-to-br from-gray-600 to-gray-800 text-white">
-                          {firstName.charAt(0).toUpperCase()}
-                        </AvatarFallback>
+                        <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${fullName}`} alt={fullName} />
                       )
                     }
 
@@ -83,15 +82,13 @@ export default function MapHeader({
                   <Avatar className="w-20 h-20 mb-2">
                     {
                       profileImage ? (
-                        <AvatarImage src={profileImage} alt={firstName} />
+                        <AvatarImage src={profileImage} alt={fullName} className="object-cover w-full h-full"/>
                       ) : (
-                        <AvatarFallback className="text-4xl bg-gradient-to-br from-gray-600 to-gray-800 text-white">
-                          {firstName.charAt(0).toUpperCase()}
-                        </AvatarFallback>
+                        <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${fullName}`} alt={fullName} />
                       )
                     }
                   </Avatar>
-                  <h2 className="text-lg font-semibold">{firstName}</h2>
+                  <h2 className="text-lg font-semibold">{fullName}</h2>
                   <p className="text-sm text-muted-foreground">{email}</p>
                   <Button variant="outline" className="mt-4" onClick={onOpenSettings}>
                     <Settings className="mr-2 h-4 w-4" />

--- a/Front-End/src/features/authentication/components/UserProfilePage.tsx
+++ b/Front-End/src/features/authentication/components/UserProfilePage.tsx
@@ -34,12 +34,10 @@ export default function UserProfilePage({ onClose }: UserProfilePageProps) {
                 <Avatar className="w-20 h-20">
                   {profileImage ? (
                     console.log("Profile Image:", profileImage),
-                    <AvatarImage src={profileImage} alt={`${firstName} ${lastName}`} />
+                    <AvatarImage src={profileImage} alt={`${firstName} ${lastName}`} className="object-cover w-full h-full" />
                   ) : (
                     console.log("Profile Image not:", profileImage),
-                  <AvatarFallback className="text-3xl bg-gradient-to-br from-gray-600 to-gray-800 text-white">
-                    {firstName.charAt(2).toUpperCase()}
-                  </AvatarFallback>
+                    <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${firstName}`} alt={firstName} />
                   )}
                 </Avatar>
                 <div>

--- a/Front-End/src/features/map/components/ReviewItem.tsx
+++ b/Front-End/src/features/map/components/ReviewItem.tsx
@@ -45,7 +45,7 @@ export default function ReviewItem({ review }: ReviewItemProps) {
           <Avatar>
             {
               review.profileImage ? (
-                <AvatarImage src={review.profileImage} alt={review.username} />
+                <AvatarImage src={review.profileImage} alt={review.username} className="object-cover w-full h-full"/>
               ) : (
                 <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${review.username}`} alt={review.username} />
               )


### PR DESCRIPTION
Updated avatar components to use full names for alt text and fallback images, ensuring consistent display with profile images or generated initials. Replaced AvatarFallback with Dicebear-generated SVGs for users without profile images. Also, updated user display to show full names instead of just first names.